### PR TITLE
MacOS Catalina - Reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,61 +21,61 @@ cache: ccache
 
 jobs:
   include:
-#    - name: "Ubuntu 18.04 lib build gcc"
-#      os: linux
-#      dist: bionic
-#      compiler: gcc
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-#    - name: "Ubuntu 20.04 lib build gcc"
-#      os: linux
-#      dist: focal
-#      compiler: gcc
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-#    - name: "Ubuntu 18.04 lib build clang"
-#      os: linux
-#      dist: bionic
-#      compiler: clang
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-#    - name: "Ubuntu 20.04 lib build clang"
-#      os: linux
-#      dist: focal
-#      compiler: clang
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-#    - name: "Ubuntu 18.04 package build gcc"
-#      os: linux
-#      dist: bionic
-#      compiler: gcc
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-#    - name: "Ubuntu 20.04 package build gcc"
-#      os: linux
-#      dist: focal
-#      compiler: gcc
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-#    - name: "Ubuntu 18.04 package build clang"
-#      os: linux
-#      dist: bionic
-#      compiler: clang
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-#    - name: "Ubuntu 20.04 package build clang"
-#      os: linux
-#      dist: focal
-#      compiler: clang
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-#    - name: "MacOS Mojave lib build"
-#      os: osx
-#      osx_image: xcode11.3
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-#    - name: "MacOS Mojave package build"
-#      os: osx
-#      osx_image: xcode11.3
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+    - name: "Ubuntu 18.04 lib build gcc"
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+    - name: "Ubuntu 20.04 lib build gcc"
+      os: linux
+      dist: focal
+      compiler: gcc
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+    - name: "Ubuntu 18.04 lib build clang"
+      os: linux
+      dist: bionic
+      compiler: clang
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+    - name: "Ubuntu 20.04 lib build clang"
+      os: linux
+      dist: focal
+      compiler: clang
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+    - name: "Ubuntu 18.04 package build gcc"
+      os: linux
+      dist: bionic
+      compiler: gcc
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+    - name: "Ubuntu 20.04 package build gcc"
+      os: linux
+      dist: focal
+      compiler: gcc
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+    - name: "Ubuntu 18.04 package build clang"
+      os: linux
+      dist: bionic
+      compiler: clang
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+    - name: "Ubuntu 20.04 package build clang"
+      os: linux
+      dist: focal
+      compiler: clang
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+    - name: "MacOS Mojave lib build"
+      os: osx
+      osx_image: xcode11.3
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+    - name: "MacOS Mojave package build"
+      os: osx
+      osx_image: xcode11.3
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
     - name: "MacOS Catalina lib build"
       os: osx
-      osx_image: xcode12.2
+      osx_image: xcode12
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
     - name: "MacOS Catalina package build"
       os: osx
-      osx_image: xcode12.2
+      osx_image: xcode12
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
       
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,61 +21,61 @@ cache: ccache
 
 jobs:
   include:
-    - name: "Ubuntu 18.04 lib build gcc"
-      os: linux
-      dist: bionic
-      compiler: gcc
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-    - name: "Ubuntu 20.04 lib build gcc"
-      os: linux
-      dist: focal
-      compiler: gcc
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-    - name: "Ubuntu 18.04 lib build clang"
-      os: linux
-      dist: bionic
-      compiler: clang
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-    - name: "Ubuntu 20.04 lib build clang"
-      os: linux
-      dist: focal
-      compiler: clang
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-    - name: "Ubuntu 18.04 package build gcc"
-      os: linux
-      dist: bionic
-      compiler: gcc
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-    - name: "Ubuntu 20.04 package build gcc"
-      os: linux
-      dist: focal
-      compiler: gcc
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-    - name: "Ubuntu 18.04 package build clang"
-      os: linux
-      dist: bionic
-      compiler: clang
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-    - name: "Ubuntu 20.04 package build clang"
-      os: linux
-      dist: focal
-      compiler: clang
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-    - name: "MacOS Mojave lib build"
-      os: osx
-      osx_image: xcode11.3
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
-    - name: "MacOS Mojave package build"
-      os: osx
-      osx_image: xcode11.3
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+#    - name: "Ubuntu 18.04 lib build gcc"
+#      os: linux
+#      dist: bionic
+#      compiler: gcc
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+#    - name: "Ubuntu 20.04 lib build gcc"
+#      os: linux
+#      dist: focal
+#      compiler: gcc
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+#    - name: "Ubuntu 18.04 lib build clang"
+#      os: linux
+#      dist: bionic
+#      compiler: clang
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+#    - name: "Ubuntu 20.04 lib build clang"
+#      os: linux
+#      dist: focal
+#      compiler: clang
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+#    - name: "Ubuntu 18.04 package build gcc"
+#      os: linux
+#      dist: bionic
+#      compiler: gcc
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+#    - name: "Ubuntu 20.04 package build gcc"
+#      os: linux
+#      dist: focal
+#      compiler: gcc
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+#    - name: "Ubuntu 18.04 package build clang"
+#      os: linux
+#      dist: bionic
+#      compiler: clang
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+#    - name: "Ubuntu 20.04 package build clang"
+#      os: linux
+#      dist: focal
+#      compiler: clang
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
+#    - name: "MacOS Mojave lib build"
+#      os: osx
+#      osx_image: xcode11.3
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+#    - name: "MacOS Mojave package build"
+#      os: osx
+#      osx_image: xcode11.3
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
     - name: "MacOS Catalina lib build"
       os: osx
-      osx_image: xcode12
+      osx_image: xcode12.2
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
     - name: "MacOS Catalina package build"
       os: osx
-      osx_image: xcode12
+      osx_image: xcode12.2
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
       
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,13 @@ addons:
     - patchelf
     - cmake
     - bats
-    update: false
+    update: true
   homebrew:
     packages:
     - cmake
     - bats-core
     - ccache
-    update: false
+#    update: true
 
 # activating ccache on MacOS.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,13 +69,13 @@ jobs:
 #      os: osx
 #      osx_image: xcode11.3
 #      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-#    - name: "MacOS Catalina lib build"
-#      os: osx
-#      osx_image: xcode12.2
-#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+    - name: "MacOS Catalina lib build"
+      os: osx
+      osx_image: xcode12
+      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
     - name: "MacOS Catalina package build"
       os: osx
-      osx_image: xcode12.2
+      osx_image: xcode12
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
       
 
@@ -87,13 +87,13 @@ addons:
     - patchelf
     - cmake
     - bats
-    update: true
+    update: false
   homebrew:
     packages:
     - cmake
     - bats-core
     - ccache
-    update: true
+    update: false
 
 # activating ccache on MacOS.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,11 @@ jobs:
 #      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
     - name: "MacOS Catalina lib build"
       os: osx
-      osx_image: xcode12
+      osx_image: xcode12.2
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
     - name: "MacOS Catalina package build"
       os: osx
-      osx_image: xcode12
+      osx_image: xcode12.2
       env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
       
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,8 @@ addons:
     - bats-core
     - ccache
 #    update: true
+# Uncomment this line if the latest update of homebrew is required.  This will
+# increase the overall build time of each platform.
 
 # activating ccache on MacOS.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,10 @@ jobs:
 #      os: osx
 #      osx_image: xcode11.3
 #      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=ON
-    - name: "MacOS Catalina lib build"
-      os: osx
-      osx_image: xcode12.2
-      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
+#    - name: "MacOS Catalina lib build"
+#      os: osx
+#      osx_image: xcode12.2
+#      env: INSTALL_PREFIX="~/helib_install" PACKAGE_BUILD=OFF
     - name: "MacOS Catalina package build"
       os: osx
       osx_image: xcode12.2

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 HElib
 =====
 
-<!--- Commenting travis banner out as we don't have access to the free tier anymore --->
-<!--- When and if the free tier is reinstated, we will put the banner back  --->
-<!--- Our releases are tested in 14 different configuration in a private DevOps environement   --->
-<!--- [![Build Status](https://travis-ci.com/IBM-HElib/HElib.svg?branch=master)](https://travis-ci.com/IBM-HElib/HElib) ---> 
+[![Build Status](https://travis-ci.com/IBM-HElib/HElib.svg?branch=master)](https://travis-ci.com/IBM-HElib/HElib)
 
 HElib is an open-source ([Apache License v2.0][5]) software library that
 implements [homomorphic encryption][6] (HE). Currently available schemes are the


### PR DESCRIPTION
An attempt at reducing the build time on Travis for MacOS Catalina package build as it seems to be timing out at 50 minutes and causing the builds to fail.

To mitigate this I have disabled homebrew update which seems to have reduced the time to ~30-35 minutes.