### PR TITLE
changes the links to homenc to IBM-HElib in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ HElib is distributed under the terms of the [Apache License v2.0][5].
   [7]: http://eprint.iacr.org/2014/106       "algorithms"
   [8]: http://eprint.iacr.org/2014/873       "bootstrapping"
   [9]: http://eprint.iacr.org/2016/421       "CKKS16"
-  [10]: https://github.com/homenc/HElib      "GitHubPages"
+  [10]: https://github.com/IBM-HElib/HElib      "GitHubPages"
   [11]: https://eprint.iacr.org/2020/1481    "HElib Design"
   

--- a/docker/build_and_test/README.md
+++ b/docker/build_and_test/README.md
@@ -82,11 +82,11 @@ Additionally, one can select a specific branch to build and test using the `-b
    ```
    For example running this command
    ```
-   docker run --name my_ubuntu_test he-ready-ubuntu:20.04 ./root/build_and_test_helib.sh -r https://github.com/homenc/HElib.git -lt
+   docker run --name my_ubuntu_test he-ready-ubuntu:20.04 ./root/build_and_test_helib.sh -r https://github.com/IBM-HElib/HElib.git -lt
    ```
    will run an Ubuntu 20.04 container called `my_ubuntu_test` with the
    following custom options:
-   - the `-r` flag will instead clone [homenc/HElib](https://github.com/homenc/HElib)
+   - the `-r` flag will instead clone [IBM-HElib/HElib](https://github.com/IBM-HElib/HElib)
    - because the `-b` was not specified the master branch will be tested by default
    - the `-l` flag tells the script to build HElib using the library build
    - the `-t` flag tells the script to only run the HElib Google tests and nothing else

--- a/docker/build_and_test/README.md
+++ b/docker/build_and_test/README.md
@@ -82,11 +82,11 @@ Additionally, one can select a specific branch to build and test using the `-b
    ```
    For example running this command
    ```
-   docker run --name my_ubuntu_test he-ready-ubuntu:20.04 ./root/build_and_test_helib.sh -r https://github.com/IBM-HElib/HElib.git -lt
+   docker run --name my_ubuntu_test he-ready-ubuntu:20.04 ./root/build_and_test_helib.sh -r https://github.com/homenc/HElib.git -lt
    ```
    will run an Ubuntu 20.04 container called `my_ubuntu_test` with the
    following custom options:
-   - the `-r` flag will instead clone [IBM-HElib/HElib](https://github.com/IBM-HElib/HElib)
+   - the `-r` flag will instead clone [homenc/HElib](https://github.com/homenc/HElib)
    - because the `-b` was not specified the master branch will be tested by default
    - the `-l` flag tells the script to build HElib using the library build
    - the `-t` flag tells the script to only run the HElib Google tests and nothing else

--- a/documentation/mainpage.dox
+++ b/documentation/mainpage.dox
@@ -10,7 +10,7 @@ optimizations to make homomorphic evaluation runs faster, focusing mostly on
 effective use of the <a href="http://eprint.iacr.org/2011/133">Smart-Vercauteren</a> ciphertext packing techniques and
 the <a href="http://eprint.iacr.org/2012/099">Gentry-Halevi-Smart</a> optimizations.
 
-Please refer to <a href="https://github.com/homenc/HElib/blob/master/CKKS-security.md">CKKS-security.md</a> for the latest discussion on the security of the CKKS scheme implementation in HElib.
+Please refer to <a href="https://github.com/IBM-HElib/HElib/blob/master/CKKS-security.md">CKKS-security.md</a> for the latest discussion on the security of the CKKS scheme implementation in HElib.
 
 Articles that describe some aspects of HElib include:
 
@@ -31,6 +31,6 @@ HElib is written in C++17 and uses the <a href="http://www.shoup.net/ntl/">NTL</
 
 HElib is distributed under the terms of the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a>.  
 
-For code downloads, full installation instructions, example programs and tutorials, visit <a href="https://github.com/homenc/HElib">HElib GitHub Pages</a>.
+For code downloads, full installation instructions, example programs and tutorials, visit <a href="https://github.com/IBM-HElib/HElib">HElib GitHub Pages</a>.
 
 **/

--- a/examples/BGV_country_db_lookup/BGV_country_db_lookup.cpp
+++ b/examples/BGV_country_db_lookup/BGV_country_db_lookup.cpp
@@ -18,7 +18,7 @@
 // code originally written by Jack Crawford for a lunch and learn
 // session at IBM Research (Hursley) in 2019.
 // The original example code ships with HElib and can be found at
-// https://github.com/homenc/HElib/tree/master/examples/BGV_database_lookup
+// https://github.com/IBM-HElib/HElib/tree/master/examples/BGV_database_lookup
 
 #include <iostream>
 

--- a/examples/BGV_country_db_lookup/README.md
+++ b/examples/BGV_country_db_lookup/README.md
@@ -204,7 +204,7 @@ This country lookup example is derived from an earlier BGV database demo code
 originally written by Jack Crawford for a lunch and learn session at IBM
 Research (Hursley) in 2019. The original demo code ships with HElib and can be
 found
-[here](https://github.com/homenc/HElib/tree/v1.0.2/examples/BGV_database_lookup).
+[here](https://github.com/IBM-HElib/HElib/tree/v1.0.2/examples/BGV_database_lookup).
 
 ## Appendix - Full List of Countries
 To view the options available for this demo, see the


### PR DESCRIPTION
found some links that were still pointing to homenc helib and are now pointing to ibm-helib helib